### PR TITLE
Update tests and add linter configuration

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,51 @@
+run:
+  tests: true
+  allow-parallel-runners: false
+linters-settings:
+  errcheck:
+    check-type-assertions: true
+  govet:
+    enable-all: true
+  goimports:
+    local-prefixes: github.com/kaudit/api
+  gocyclo:
+    min-complexity: 10
+  misspell:
+    locale: US
+linters:
+  enable:
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - typecheck
+    - unused
+    - gocyclo
+    - gofmt
+    - goimports
+    - misspell
+    - unparam
+    - revive
+  disable:
+    - depguard
+    - dupl
+    - gochecknoglobals
+    - gochecknoinits
+  presets:
+    - bugs
+    - unused
+  fast: false
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - govet
+      text: "fieldalignment:"
+    - path: _test\.go
+      linters:
+        - gocyclo
+        - errcheck
+        - dupl
+        - gosec
+        - gochecknoglobals

--- a/val_test.go
+++ b/val_test.go
@@ -30,7 +30,7 @@ func TestHandleValidatorError(t *testing.T) {
 		resultErr := handleValidatorError(err)
 
 		require.Error(t, resultErr)
-		assert.Equal(t, expectedErr, expectedErr)
+		assert.Contains(t, resultErr.Error(), expectedErr)
 	})
 
 	t.Run("unexpected error", func(t *testing.T) {


### PR DESCRIPTION
### Description  

- Replaced `assert.Equal` with `assert.Contains` in tests to improve error validation.  
- Added `.golangci.yaml` configuration to enforce code quality through multiple linters with custom settings.  

### Checklist  

- [ ] Reviewed the code changes  
- [ ] Tested functionality thoroughly