### PR TITLE
Add validation for 'spec.type' and update dependencies

### DIFF
--- a/custom_validations.go
+++ b/custom_validations.go
@@ -63,6 +63,7 @@ func fieldSelectorValidator(v *validator.Validate) {
 			"spec.unschedulable": {},
 			"status.hostIP":      {},
 			"status.podIP":       {},
+			"spec.type":          {},
 		}
 
 		value := fl.Field().String()

--- a/go.mod
+++ b/go.mod
@@ -2,27 +2,28 @@ module github.com/kaudit/val
 
 go 1.23.0
 
-toolchain go1.23.7
-
 require (
 	github.com/go-playground/validator/v10 v10.26.0
 	github.com/stretchr/testify v1.10.0
-	k8s.io/apimachinery v0.32.3
+	k8s.io/apimachinery v0.32.4
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.9 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/kr/pretty v0.3.1 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	golang.org/x/crypto v0.36.0 // indirect
-	golang.org/x/net v0.38.0 // indirect
-	golang.org/x/sys v0.31.0 // indirect
-	golang.org/x/text v0.23.0 // indirect
+	github.com/rogpeppe/go-internal v1.14.1 // indirect
+	golang.org/x/crypto v0.37.0 // indirect
+	golang.org/x/net v0.39.0 // indirect
+	golang.org/x/sys v0.33.0 // indirect
+	golang.org/x/text v0.24.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
-	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
+	k8s.io/utils v0.0.0-20250502105355-0f33e8f1c979 // indirect
 )

--- a/val_test.go
+++ b/val_test.go
@@ -243,6 +243,9 @@ func TestFieldSelectorValidator_AllSyntax(t *testing.T) {
 		{"DoubleEqual", fieldSelectorInput{"metadata.name==default"}, true},
 		{"NotEqual", fieldSelectorInput{"metadata.name!=kube-system"}, true},
 		{"MultipleAND", fieldSelectorInput{"metadata.name=default,status.phase=Running"}, true},
+		{"SpecType", fieldSelectorInput{"spec.type=ClusterIP"}, true},
+		{"SpecTypeNotEqual", fieldSelectorInput{"spec.type!=NodePort"}, true},
+		{"SpecTypeWithOthers", fieldSelectorInput{"metadata.namespace=default,spec.type=LoadBalancer"}, true},
 
 		// invalid syntax
 		{"InvalidOperator", fieldSelectorInput{"metadata.name~value"}, false},


### PR DESCRIPTION
### Summary

This pull request introduces a new validation rule for the `spec.type` field, aiming to enhance input validation within our application. Additionally, Go module dependencies have been updated to their latest versions to improve compatibility, security, and stability.

### Changes

- Added a validation rule for `spec.type` in custom validation logic.
- Updated Go modules to their latest versions for improved support and fixes.

### Checklist

- [x] Tests for the introduced feature or update are included.
- [x] Documentation is updated where necessary.
- [x] Code changes were reviewed thoroughly.

### Additional Context (if any)

N