### PR TITLE
Update README to include `spec.type` as a valid field key

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ The following field keys are currently allowed:
 - `spec.unschedulable`
 - `status.hostIP`
 - `status.podIP`
+- `spec.type`
 
 Any other field keys will cause the validation to fail.
 


### PR DESCRIPTION
Updated the README documentation to reflect `spec.type` as a valid field key for validation. This change ensures the documentation accurately represents the supported fields